### PR TITLE
Add support for Pegasus topology 

### DIFF
--- a/02-hybrid-computing-workflows.ipynb
+++ b/02-hybrid-computing-workflows.ipynb
@@ -27,7 +27,9 @@
     "# A Sample Problem\n",
     "This section recreates the [Quantum-Classical Hybrid Computing: Getting Started](01-hybrid-computing-getting-started.ipynb) problem for use in the following sections. \n",
     "\n",
-    "<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">Note: Problem size (nodes and density of edges) selected below ensures that runtimes on compute resources (virtual CPUs) provided by the Leap environment do not exceed a few minutes.</div>"
+    "<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">Note: Problem size (nodes and density of edges) selected below ensures that runtimes on compute resources (virtual CPUs) provided by the Leap environment do not exceed a few minutes.</div>\n",
+    "\n",
+    "<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">Note: The code cell below imports from <code>helpers</code>, a folder colocated with this Jupyter Notebook. Users running it in <a href=\"https://cloud.dwavesys.com/leap\">Leap</a> can see helper functions by selecting <i>Jupyter File Explorer View</i> on the <i>Online Learning</i> page.</div>"
    ]
   },
   {
@@ -1003,7 +1005,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sampler `sampler_pre` is created by calculating a clique (fully-connected graph) minor-embedding that can be used for any problem of up to the target subproblem size, `sub_size`.  "
+    "Sampler `sampler_pre` is created by calculating a clique (fully-connected graph) minor-embedding that can be used for any problem of up to the target subproblem size, `sub_size`.  \n",
+    "\n",
+    "Helper function `qpu_working_graph` creates a [*dwave-networkx*](https://docs.ocean.dwavesys.com/en/stable/docs_dnx/sdk_index.html) graph that represents the *working graph* of the QPU selected above by `DWaveSampler`, a Pegasus or Chimera graph with the same sets of nodes (qubits) and edges (couplers) as the QPU. Ocean software's [*minorminer*](https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/sdk_index.html) finds an embedding for the required clique size in the working graph. "
    ]
   },
   {
@@ -1012,12 +1016,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from helpers.qpu import qpu_working_graph \n",
     "from dwave.system import FixedEmbeddingComposite\n",
-    "from dwave.embedding.chimera import find_clique_embedding\n",
+    "from minorminer.busclique import find_clique_embedding\n",
     "\n",
     "sub_size = 40\n",
+    "qpu_working_graph = qpu_working_graph(sampler_qpu)\n",
+    "clique_embedding = find_clique_embedding(sub_size, qpu_working_graph)\n",
     "\n",
-    "clique_embedding = find_clique_embedding(sub_size, 16, target_edges=sampler_qpu.edgelist)\n",
     "sampler_pre = FixedEmbeddingComposite(sampler_qpu, clique_embedding)"
    ]
   },
@@ -1108,7 +1114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/helpers/qpu.py
+++ b/helpers/qpu.py
@@ -1,0 +1,30 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Helper functions related to D-Wave systems
+"""
+
+import dwave_networkx as dnx
+
+def qpu_working_graph(qpu):
+    "Return a dwave_networkx graph representing the working graph of a given QPU."
+    
+    dnx_graphs = {'chimera': dnx.chimera_graph, 'pegasus': dnx.pegasus_graph}
+
+    dnx_graph = dnx_graphs[qpu.properties["topology"]["type"]]
+
+    return dnx_graph(qpu.properties["topology"]["shape"][0], 
+                     node_list=qpu.nodelist, 
+                     edge_list=qpu.edgelist)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk==2.1.1
+dwave-ocean-sdk==2.6.0
 
 jupyter
 jupyter_contrib_nbextensions


### PR DESCRIPTION
An alternative would be to add a `QPUSubproblemDWaveCliqueSampler` in dwave-hybrid, though the current method of using minorminer.busclique directly has the advantage of not needing to set a direct solver name (`sampler_qpu = DWaveSampler(solver={'qpu': True})` followed by `sampler_qpu = DWaveCliqueSampler(solver=sampler_qpu.solver.name)` to ensure both branches use the same QPU).

CC @mdecandia 