### PR TITLE
Add problem labels

### DIFF
--- a/01-hybrid-computing-getting-started.ipynb
+++ b/01-hybrid-computing-getting-started.ipynb
@@ -328,7 +328,8 @@
     "sampler_qpu = DWaveSampler(solver={'num_qubits__gt':1800})\n",
     "\n",
     "result = hybrid.KerberosSampler().sample(bqm, max_iter=10, \n",
-    "                                              max_subproblem_size=70, \n",
+    "                                              max_subproblem_size=70,\n",
+    "                                              qpu_sampler=sampler_qpu,\n",
     "                                              qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solution with {} nodes at energy {}.\".format(np.sum(result.record.sample), \n",
     "                                                                 result.first.energy))"

--- a/01-hybrid-computing-getting-started.ipynb
+++ b/01-hybrid-computing-getting-started.ipynb
@@ -148,7 +148,7 @@
     "from dwave.system import LeapHybridSampler\n",
     "import numpy as np\n",
     "\n",
-    "result = LeapHybridSampler().sample(bqm)\n",
+    "result = LeapHybridSampler().sample(bqm, label='Notebook - Hybrid Computing 1')\n",
     "print(\"Found solution with {} nodes at energy {}.\".format(np.sum(result.record.sample), \n",
     "                                                          result.first.energy))"
    ]
@@ -198,7 +198,8 @@
     "import hybrid \n",
     "import numpy as np\n",
     "\n",
-    "result = hybrid.KerberosSampler().sample(bqm)\n",
+    "result = hybrid.KerberosSampler().sample(bqm, \n",
+    "                                         qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solution with {} nodes at energy {}.\".format(np.sum(result.record.sample), \n",
     "                                                          result.first.energy))"
    ]
@@ -238,7 +239,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = hybrid.KerberosSampler().sample(bqm, max_iter=10)\n",
+    "result = hybrid.KerberosSampler().sample(bqm, \n",
+    "                                         max_iter=10, \n",
+    "                                         qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solution with {} nodes at energy {}.\".format(np.sum(result.record.sample), \n",
     "                                                                 result.first.energy))"
    ]
@@ -266,7 +269,9 @@
    "source": [
     "# Placeholder cell for exercise. Modify and run your code here.\n",
     "\n",
-    "result = hybrid.KerberosSampler().sample(bqm, max_iter=10)\n",
+    "result = hybrid.KerberosSampler().sample(bqm, \n",
+    "                                         max_iter=10, \n",
+    "                                         qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solutions with energy\", result.record.energy)"
    ]
   },
@@ -282,7 +287,8 @@
     "                                         num_reads=3, \n",
     "                                         max_iter=10, \n",
     "                                         qpu_reads=100, \n",
-    "                                         tabu_timeout=200)\n",
+    "                                         tabu_timeout=200,\n",
+    "                                         qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solutions with energy {}.\".format(result.record.energy))"
    ]
   },
@@ -323,7 +329,7 @@
     "\n",
     "result = hybrid.KerberosSampler().sample(bqm, max_iter=10, \n",
     "                                              max_subproblem_size=70, \n",
-    "                                              qpu_sampler=sampler_qpu)\n",
+    "                                              qpu_params={'label': 'Notebook - Hybrid Computing 1'})\n",
     "print(\"Found solution with {} nodes at energy {}.\".format(np.sum(result.record.sample), \n",
     "                                                                 result.first.energy))"
    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk>=3.2.1
+dwave-ocean-sdk>=3.3.0
 
 jupyter
 jupyter_contrib_nbextensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk>=3.0.0
+dwave-ocean-sdk>=3.2.1
 
 jupyter
 jupyter_contrib_nbextensions


### PR DESCRIPTION
Placeholder PR for when an SDK is released that supports labels. I tested with https://github.com/dwavesystems/dwave-cloud-client/releases/tag/0.8.3 and https://github.com/dwavesystems/dwave-ocean-sdk/releases/tag/3.2.0 locally. Will update SDK tag if needed.
Note that I added problem labels to notebook 1 only. It is possible to add labels via `sampling_params` to the other two JNs but I think such a construct distracts users from the subject at hand and so is not worth the benefit. Even for notebook 1 it's not great but at least there they have the simple example of `result = LeapHybridSampler().sample(bqm, label='Notebook - Hybrid Computing 1')` to grasp first so later they're likely to skim this. 