### PR TITLE
Fix failing py 3.9 tests (linux)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ autopep8
 matplotlib~=3.0
 
 nbformat
-nbconvert==5.6.1
+nbconvert


### PR DESCRIPTION
Unpinning `nbconvert` fixes the failing python 3.9 tests in linux that are caused by the new `jupyter-client>6.1.12` working with `nbconvert<6` (see https://github.com/jupyter/jupyter_client/issues/637 for details). 

Alternatively, we could pin `nbconvert` to a later version for python 3.9.

The part that confuses me about this is that the OSX and Windows tests did not fail (also using `jupyter-client==7.0.1` and `nbconvert==5.6.1`) on the CI, but fails for me locally (OSX). 
